### PR TITLE
Allow editable resource group

### DIFF
--- a/extensions/azurerbac/azurerbac/task.json
+++ b/extensions/azurerbac/azurerbac/task.json
@@ -44,7 +44,10 @@
       "label": "Resource Group",
       "type": "pickList",
       "required": true,
-      "helpMarkDown": "Select the resource group for the assignments"
+      "helpMarkDown": "Select the resource group for the assignments",
+      "properties": {
+        "EditableOptions": "True"
+      }
     },
     {
       "name": "AzureRoleAssignments",


### PR DESCRIPTION
Changed property for the resource group field to allow the user to edit. This then allows the use of variable driven values such as $(resourcegroup)